### PR TITLE
feat: add TypeScript typings

### DIFF
--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -1,0 +1,2 @@
+declare const fastCartesian: <T>(arrays: T[][]) => T[][]
+export default fastCartesian


### PR DESCRIPTION
Fixes #6.

The type definition is really rather simple, but since `fastCartesian` is really the only exported function this should be all there is to it. I've also tested that this actually works for our use case.

Please let me know if you want anything changed!