### PR TITLE
Update typescript definition to be more precise

### DIFF
--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -1,2 +1,5 @@
-declare const fastCartesian: <T>(arrays: T[][]) => T[][]
+declare const fastCartesian: <TFactors extends any[][]>(factors: [...TFactors]) => {
+  [TFactor in keyof TFactors]: TFactors[TFactor] extends Array<infer TUnArrayed> ? TUnArrayed : never
+}[]
+
 export default fastCartesian


### PR DESCRIPTION
**Which problem is this pull request solving?**

The typescript definition is wrong. It only supports 2 arrays from the same type as argument.

**List other issues or pull requests related to this problem**

/

**Describe the solution you've chosen**

I have updated the typescript definition to use generic rest parameters.

**Describe alternatives you've considered**

/

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [ ] I have added tests (we are enforcing 100% test coverage).
- [ ] I have added documentation in the `README.md`, the `docs` directory (if
      any) and the `examples` directory (if any).
- [ ] The status checks are successful (continuous integration). Those can be
      seen below.
